### PR TITLE
Remove contributor-unfriendly linting rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:
-      - id: trailing-whitespace
       - id: check-merge-conflict
-      - id: end-of-file-fixer
       - id: check-case-conflict
       - id: detect-private-key
       - id: check-ast


### PR DESCRIPTION
We can introduce a workflow that removes trailing whitespaces and missing newlines rather than going through additional reviews and fixes with contributions