### PR TITLE
Add option to avoid litmus uninstall before chaos run

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -7,6 +7,7 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    litmus_uninstall_before_run: True                      # If you want to uninstall litmus before a new run starts
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   container_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/container_etcd.yml

--- a/config/config_performance.yaml
+++ b/config/config_performance.yaml
@@ -7,6 +7,7 @@ kraken:
     signal_state: RUN                                      # Will wait for the RUN signal when set to PAUSE before running the scenarios, refer docs/signal.md for more details
     litmus_version: v1.13.6                                # Litmus version to install
     litmus_uninstall: False                                # If you want to uninstall litmus if failure
+    litmus_uninstall_before_run: True                      # If you want to uninstall litmus before a new run starts
     chaos_scenarios:                                       # List of policies/chaos scenarios to load
         -   pod_scenarios:                                 # List of chaos pod scenarios to load
             - -    scenarios/etcd.yml

--- a/run_kraken.py
+++ b/run_kraken.py
@@ -49,6 +49,7 @@ def main(cfg):
         run_signal = config["kraken"].get("signal_state", "RUN")
         litmus_version = config["kraken"].get("litmus_version", "v1.9.1")
         litmus_uninstall = config["kraken"].get("litmus_uninstall", False)
+        litmus_uninstall_before_run = config["kraken"].get("litmus_uninstall_before_run", True)
         wait_duration = config["tunings"].get("wait_duration", 60)
         iterations = config["tunings"].get("iterations", 1)
         daemon_mode = config["tunings"].get("daemon_mode", False)
@@ -181,10 +182,11 @@ def main(cfg):
                             logging.info("Running litmus scenarios")
                             litmus_namespace = "litmus"
                             if not litmus_installed:
-                                # Will always uninstall first
+                                # Remove Litmus resources before running the scenarios
                                 common_litmus.delete_chaos(litmus_namespace)
                                 common_litmus.delete_chaos_experiments(litmus_namespace)
-                                common_litmus.uninstall_litmus(litmus_version, litmus_namespace)
+                                if litmus_uninstall_before_run:
+                                    common_litmus.uninstall_litmus(litmus_version, litmus_namespace)
                                 common_litmus.install_litmus(litmus_version, litmus_namespace)
                                 common_litmus.deploy_all_experiments(litmus_version, litmus_namespace)
                                 litmus_installed = True


### PR DESCRIPTION
Adds an option to avoid uninstalling Litmus before running the chaos scenarios. This will allow for the creation of resources in the Litmus namespace before running Kraken - right now the namespace and all the resources in it get deleted at the start of the run.