### PR TITLE
Workaround for paramiko/paramiko#2038

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ itsdangerous==2.0.1
 werkzeug==2.0.3
 aliyun-python-sdk-core-v3
 aliyun-python-sdk-ecs
+cryptography==36.0.2 # Remove once https://github.com/paramiko/paramiko/issues/2038 gets fixed.


### PR DESCRIPTION
When running a fresh install, the following warning is issued:

```
/home/janosdebugs/PycharmProjects/krkn/venv/lib/python3.8/site-packages/paramiko/transport.py:236: CryptographyDeprecationWarning: Blowfish has been deprecated
  "class": algorithms.Blowfish,
```

This PR downgrades the [cryptography package](https://pypi.org/project/cryptography/) to version 36.0.2 until paramiko/paramiko#2038 gets fixed.