### PR TITLE
Fixes #245: running docker-compose for most people

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,7 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-    ports:
-      - "9200:9200"
-      - "9300:9300"
+    network_mode: host
     environment:
       discovery.type: single-node
   kibana:
@@ -17,8 +15,7 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-    ports:
-      - "5601:5601"
+    network_mode: host
     environment:
       ELASTICSEARCH_HOSTS: "http://0.0.0.0:9200"
   cerberus:
@@ -28,8 +25,7 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
-    ports:
-      - "8080:8080"
+    network_mode: host
     volumes:
        - ./config/cerberus.yaml:/root/cerberus/config/config.yaml:Z  # Modify the config in case of the need to monitor additional components
-       - /root/.kube/config:/root/.kube/config:Z
+       - ${HOME}/.kube/config:/root/.kube/config:Z


### PR DESCRIPTION
This PR fixes #245 with the following changes:

**Switching to host networking**

Host networking will make Kraken work on setups where Kubernetes/OpenShift is exposed on 127.0.0.1. This is not a big change since all the ports of the services (ES, Kibana) were already mapped to the host anyway.

**Using `${HOME}` instead of `/root`**

Docker-compose has the ability to use environment variables. While this may not be 100% portable to systems where `$HOME` is not set, it is better than hard-coding `/root`.