### PR TITLE
Added support for multi-node clusters for KinD in Kraken

### DIFF
--- a/.github/workflows/kind_action.yml
+++ b/.github/workflows/kind_action.yml
@@ -1,0 +1,14 @@
+name: KinD Cluster
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create KinD cluster
+        uses: chaos-kubox/actions/kind@main

--- a/CI/.kind-config.yaml
+++ b/CI/.kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: control-plane
+  - role: control-plane
+  - role: worker
+  - role: worker


### PR DESCRIPTION
Support for creating multi-node KinD clusters in Kraken using composite actions. Tested on:

https://github.com/Sau1506mya/New_Test_Repo
https://github.com/Sau1506mya/Test_action