### PR TITLE
Removing cryptography pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,3 @@ itsdangerous==2.0.1
 werkzeug==2.0.3
 aliyun-python-sdk-core-v3
 aliyun-python-sdk-ecs
-cryptography==36.0.2 # Remove once https://github.com/paramiko/paramiko/issues/2038 gets fixed.


### PR DESCRIPTION
Remove `cryptography=36.0.2` pinning because paramiko/paramiko#2038 is now fixed.